### PR TITLE
Index fix to tau emulator

### DIFF
--- a/module_neural_net.F90
+++ b/module_neural_net.F90
@@ -300,7 +300,7 @@ contains
                 y_in(i) = ys(j)
             else
                 slope = (ys(j + 1) - ys(j)) / (xs(j + 1) - xs(j))
-                y_in(j) = slope * (x_in(i) - xs(j)) + ys(j) 
+                y_in(i) = slope * (x_in(i) - xs(j)) + ys(j) 
             end if
         end do
     end subroutine linear_interp_forward
@@ -320,7 +320,7 @@ contains
                 y_in(i) = ys(j)
             else
                 slope = (ys(j + 1) - ys(j)) / (xs(j + 1) - xs(j))
-                y_in(j) = slope * (x_in(i) - xs(j)) + ys(j) 
+                y_in(i) = slope * (x_in(i) - xs(j)) + ys(j) 
             end if
         end do
     end subroutine linear_interp_inverse


### PR DESCRIPTION
I had a mixup in my indexing and assigned the wrong variable to y_in in the else statement. y_in should be indexed with i instead of j in this instance since j is indexing over the quantile-value arrays while i is indexing over the examples, and we are trying to do linear interpolation between the nearest quantiles for the values in x_in.  